### PR TITLE
Added ILogger interface

### DIFF
--- a/EppLib/Debug.cs
+++ b/EppLib/Debug.cs
@@ -11,40 +11,29 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System.Globalization;
-using System.IO;
-using System.Text;
+using System;
+
 
 namespace EppLib
 {
     public static class Debug
     {
-        public static string LogFilename = "easyepplog.txt";
+        static IDebugger Debugger = new SimpleLogger();
+
+        public static void Setup(IDebugger debugger)
+        {
+            Debugger = debugger;
+        }
 
         public static void Log(byte[] bytes)
         {
-            LogMessageToFile(Encoding.Default.GetString(bytes));
+            Debugger.Log(bytes);
         }
 
         public static void Log(string str)
         {
-            Log(Encoding.Default.GetBytes(str));
-        }
-
-        private static void LogMessageToFile(string msg)
-        {
-            var sw = File.AppendText(LogFilename);
-
-            try
-            {
-                var logLine = System.String.Format( CultureInfo.InvariantCulture,"{0:G}: {1}.", System.DateTime.Now, msg);
-
-                sw.WriteLine(logLine);
-            }
-            finally
-            {
-                sw.Close();
-            }
+            Debugger.Log(str);
         }
     }
+
 }

--- a/EppLib/IDebugger.cs
+++ b/EppLib/IDebugger.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace EppLib
+{
+    public interface IDebugger
+    {
+        void Log(byte[] bytes);
+
+        void Log(string str);
+    }
+}
+

--- a/EppLib/SimpleLogger.cs
+++ b/EppLib/SimpleLogger.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using System.IO;
+using System.Globalization;
+
+namespace EppLib
+{
+    class SimpleLogger : IDebugger
+    {
+        public static string LogFilename = "easyepplog.txt";
+
+        public void Log(byte[] bytes)
+        {
+            LogMessageToFile(Encoding.UTF8.GetString(bytes));
+        }
+
+        public void Log(string str)
+        {
+            LogMessageToFile(str);
+        }
+
+        private static void LogMessageToFile(string msg)
+        {
+            var sw = File.AppendText(LogFilename);
+
+            try
+            {
+                var logLine = System.String.Format( CultureInfo.InvariantCulture,"{0:G}: {1}.", System.DateTime.Now, msg);
+
+                sw.WriteLine(logLine);
+            }
+            finally
+            {
+                sw.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added ILogger interface to allow Dependency Injection of custom loggers.
Provides a default logger (using the existing debug functionality) which is used by default.  Should have zero impact on existing users of the lib but allows overriding the logging functionality if required without actually changing the library itself and should make unit testing easier in the future (though I didn't get time to add any unit testing for this).