### PR TITLE
Abstracted away connection & read/write implementation

### DIFF
--- a/EppLib/EppLib.csproj
+++ b/EppLib/EppLib.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Extensions\Smallregistry\ContactCreate\SmallregistryContactPMCreateExtension.cs" />
     <Compile Include="Extensions\Smallregistry\ContactCreate\SmallregistryContactPPCreateExtension.cs" />
     <Compile Include="Extensions\Smallregistry\SmallregistryExtensionBase.cs" />
+    <Compile Include="ITransport.cs" />
     <Compile Include="Service.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TcpTransport.cs" />

--- a/EppLib/ITransport.cs
+++ b/EppLib/ITransport.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2012 Code Maker Inc. (http://codemaker.net)
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Xml;
+/**/
+using System.Security.Authentication;
+
+
+/*
+using OpenSSL;
+using OpenSSL.Core;
+using OpenSSL.X509;*/
+
+
+namespace EppLib
+{
+    public interface ITransport : IDisposable
+    {
+        void Connect(SslProtocols sslProtocols = SslProtocols.Tls);
+        void Disconnect();
+        void Write(XmlDocument xmlDocument);
+        byte[] Read();
+    }
+}

--- a/EppLib/Service.cs
+++ b/EppLib/Service.cs
@@ -23,9 +23,9 @@ namespace EppLib
 	/// </summary>
 	public class Service
 	{
-		private readonly TcpTransport transport;
+		private readonly ITransport transport;
 
-		public Service(TcpTransport transport)
+		public Service(ITransport transport)
 		{
 			this.transport = transport;
 		}

--- a/EppLib/TcpTransport.cs
+++ b/EppLib/TcpTransport.cs
@@ -34,7 +34,7 @@ namespace EppLib
     /// <summary>
     /// Encapsulates the TCP transport
     /// </summary>
-    public class TcpTransport : IDisposable
+    public class TcpTransport : ITransport
     {
         private SslStream stream;
 


### PR DESCRIPTION
The EPP standard does not specify the transport protocol. I ran into this with a supplier that has an implementation with EPP commands over the HTTP/s protocol.